### PR TITLE
Support disabling FirePHP (app.yml: Panda: firephp: false)

### DIFF
--- a/BEAR/BEAR/script/debug_init.php
+++ b/BEAR/BEAR/script/debug_init.php
@@ -14,8 +14,11 @@
  */
 
 require_once 'Panda.php';
-require_once 'FirePHPCore/FirePHP.class.php';
-require_once 'FirePHPCore/fb.php';
+
+if ($appConfig['Panda']['firephp'] === true) {
+    require_once 'FirePHPCore/FirePHP.class.php';
+    require_once 'FirePHPCore/fb.php';
+}
 
 // シャットダウン関数登録
 if (isset($_SERVER) && isset($_SERVER['REQUEST_URI'])

--- a/BEAR/Ro/Debug.php
+++ b/BEAR/Ro/Debug.php
@@ -143,8 +143,9 @@ class BEAR_Ro_Debug extends BEAR_Base
      */
     public function debugShowResource(BEAR_Ro $ro)
     {
+        $app = BEAR::get('app');
         $config = $ro->getConfig();
-        if (!isset($config['method'])) {
+        if (!isset($config['method']) || !function_exists('FB')) {
             return;
         }
         $labelUri = "[resource] {$config['method']} {$config['uri']}";


### PR DESCRIPTION
app.yml のPanda: firephp: を false にしても FirePHP が有効になっていたので無効になるよう改修しました。
