### PR TITLE
Panda.phpでライブモードのときに PHP Warning

### DIFF
--- a/BEAR/vendors/PEAR/Panda.php
+++ b/BEAR/vendors/PEAR/Panda.php
@@ -337,7 +337,7 @@ class Panda
                 syslog(LOG_INFO, print_r($v, true));
             }
             if (class_exists('PEAR', false)) {
-                PEAR::setErrorHandling(PEAR_Exception);
+                PEAR::setErrorHandling(PEAR_ERROR_RETURN);
             }
             set_exception_handler(array('Panda', 'onException'));
         } else {


### PR DESCRIPTION
Panda.phpでライブモードのときに PHP Warningが出ていたので修正しました。

PHP Warning:  invalid error mode in /xxx/libs/pear/php/BEAR/vendors/PEAR/PEAR.php on line 335
