### PR TITLE
change test skeleton, autoloader, add utility

### DIFF
--- a/data/app/App.php
+++ b/data/app/App.php
@@ -56,8 +56,9 @@ class App
                 $app['BEAR_Ro_Prototype']['__class'] = 'BEAR_Ro_Prototype_Debug';
                 break;
             case 100:
-                // for HTTP access UNIT test
+                // for UNIT test or HTTP access test
                 $app['core']['debug'] = true;
+                $app['App_Db']['dsn']['default'] = $app['App_Db']['dsn']['slave'] = $app['App_Db']['dsn']['test'];
                 $app['BEAR_Log']['__class'] = 'BEAR_Log_Test';
                 $app['BEAR_Resource_Request']['__class'] = 'BEAR_Resource_Request_Test';
                 break;

--- a/data/app/tests/bootstrap.php
+++ b/data/app/tests/bootstrap.php
@@ -1,16 +1,17 @@
 <?php
-// set path
+// for test
+$_SERVER['bearmode'] = 100;
+
+$loader = require dirname(__DIR__). '/vendor/autoload.php';
+/** @var $loader \Composer\Autoload\ClassLoader */
+$loader->add('', __DIR__);
+$loader->register();
+
 $appPath = realpath(__DIR__ . '/..');
-// set autoloder
-set_include_path($appPath . PATH_SEPARATOR . get_include_path());
+set_include_path($appPath . PATH_SEPARATOR . $appPath . '/libs/pear/php' . PATH_SEPARATOR . $appPath  . '/libs/pear/php/BEAR' . PATH_SEPARATOR . $appPath . '/libs/pear/php/BEAR/vendors/PEAR' . PATH_SEPARATOR . get_include_path());
+
 require_once $appPath . '/App.php';
 
-spl_autoload_register('bearTestAutolodaer');
-
-$filter = PHP_CodeCoverage_Filter::getInstance();
-$filter->removeDirectoryFromWhitelist($appPath . 'App/views');
-
-function bearTestAutolodaer($class) {
-    $file = str_replace('_', DIRECTORY_SEPARATOR, $class) . '.php';
-    require_once $file;
-}
+// extension Xdebug
+//$filter = PHP_CodeCoverage_Filter::getInstance();
+//$filter->removeDirectoryFromWhitelist($appPath . 'App/views');

--- a/data/app/tests/utility/v.php
+++ b/data/app/tests/utility/v.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * BEAR
+ *
+ * PHP versions 5
+ *
+ * @category  BEAR
+ * @package
+ * @author    Akihito Koriyama <koriyama@bear-project.net>
+ * @copyright 2011 Akihito Koriyama  All rights reserved.
+ * @license   http://opensource.org/licenses/bsd-license.php BSD
+ * @version   SVN: Release: $Id:$
+ * @link      http://www.bear-project.net/
+ */
+
+/**
+ * BEAR
+ *
+ * @category  BEAR
+ * @package
+ * @author    Akihito Koriyama <koriyama@bear-project.net>
+ * @copyright 2011 Akihito Koriyama  All rights reserved.
+ * @license   http://opensource.org/licenses/bsd-license.php BSD
+ * @version   Release: @package_version@
+ * @link      http://www.bear-project.net/
+ */
+/**
+ * Debug print 'v'
+ *
+ * @param mixed  $values    any values
+ *
+ * @return void
+ */
+function v($values = null)
+{
+    static $paramNum = 0;
+
+    // be recursive
+    $args = func_get_args();
+    if (count($args) > 1) {
+        foreach ($args as $arg) {
+            p($arg);
+        }
+    }
+    $trace = debug_backtrace();
+    $i = ($trace[0]['file'] === __FILE__ ) ? 1 : 0;
+    $file = $trace[$i]['file'];
+    $line = $trace[$i]['line'];
+    $includePath = explode(":", get_include_path());
+    // remove if include_path exists
+    foreach ($includePath as $var) {
+        if ($var != '.') {
+            $file = str_replace("{$var}/", '', $file);
+        }
+    }
+    $method = (isset($trace[1]['class'])) ? " ({$trace[1]['class']}" . '::' . "{$trace[1]['function']})" : '';
+    $fileArray = file($file, FILE_USE_INCLUDE_PATH);
+    $p = trim($fileArray[$line - 1]);
+    unset($fileArray);
+    $funcName = __FUNCTION__;
+    preg_match("/{$funcName}\((.+)[\s,\)]/is", $p, $matches);
+    $varName = isset($matches[1]) ? $matches[1] : '';
+    // for mulitple arg names
+    $varNameArray = explode(',', $varName);
+    if (count($varNameArray) === 1) {
+        $paramNum = 0;
+        $varName = $varNameArray[0];
+    } else {
+        $varName = $varNameArray[$paramNum];
+        if ($paramNum === count($varNameArray) - 1) {
+            var_dump($_ENV);
+            $paramNum = 0;
+        } else {
+            $paramNum++;
+        }
+    }
+    $label = "$varName in {$file} on line {$line}$method";
+    if (strlen(serialize($values)) > 1000000) {
+        $ouputMode = 'dump';
+    }
+    $label = (is_object($values)) ? ucwords(get_class($values)) . " $label" : $label;
+    // if CLI
+    if (PHP_SAPI === 'cli') {
+        $colorOpenReverse = "\033[7;32m";
+        $colorOpenBold = "\033[1;32m";
+        $colorOpenPlain = "\033[0;32m";
+        $colorClose = "\033[0m";
+        echo $colorOpenReverse . "$varName" . $colorClose . " = ";
+        var_dump($values);
+        echo $colorOpenPlain . "in {$colorOpenBold}{$file}{$colorClose}{$colorOpenPlain} on line {$line}$method" . $colorClose . "\n";
+        return;
+    }
+    $labelField = '<fieldset style="color:#4F5155; border:1px solid black;padding:2px;width:10px;">';
+    $labelField .= '<legend style="color:black;font-size:9pt;font-weight:bold;font-family:Verdana,';
+    $labelField .= 'Arial,,SunSans-Regular,sans-serif;">' . $label . '</legend>';
+    if (class_exists('FB', false)) {
+        $label = 'p() in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'];
+        FB::group($label);
+        FB::error($values);
+        FB::groupEnd();
+        return;
+    }
+    $pre = "<pre style=\"text-align: left;margin: 0px 0px 10px 0px; display: block; background: white; color: black; ";
+    $pre .= "border: 1px solid #cccccc; padding: 5px; font-size: 12px; \">";
+    if ($varName != FALSE) {
+        $pre .= "<span style='color: #660000;'>" . $varName . '</span>';
+    }
+    $pre .= "<span style='color: #660000;'>" . htmlspecialchars($varName) . "</span>";
+    $post = '&nbsp;&nbsp;' . "in <span style=\"color:gray\">{$file}</span> on line {$line}$method";
+    echo $pre;
+    var_dump($values);
+    echo $post;
+}


### PR DESCRIPTION
20番のPRご確認ありがとうございました。
ご指摘のとおり不備があったので、そちらは破棄頂ければと思います。
こちらでいかがでしょうか？
1. スケルトンの bootstrap で、オートロードを composer のクラスローダに変更
2. スケルトンのbootstrap にテスト用 bearmode 追加
3. スケルトン生成される App.php に上記2. のモード時にテストDBへの接続設定追加
4. スケルトンの bootstrap  PHP_CodeCoverage_Filter は、Xdebug依存なので、コメントアウト
5. スケルトンの tests/ の下に、beardemo.local にあるユーティリティ関数を追加

こちらでよろしければ、本体のtests ディレクトリも同様な変更を入れたら良いかと思います。

お手数ですが、ご確認よろしくお願いいたします。
