### PR TITLE
updateメソッドの引数のテーブル名を省略可能に

### DIFF
--- a/BEAR/Query.php
+++ b/BEAR/Query.php
@@ -409,7 +409,7 @@ class BEAR_Query extends BEAR_Base implements BEAR_Query_Interface
      *
      * @return mixed
      */
-    public function update(array $values, $where, $table, $types = null)
+    public function update(array $values, $where, $table = null, $types = null)
     {
         $db = & $this->_config['db'];
         $table = $table ? $table : $this->_config['table'];


### PR DESCRIPTION
必須になっていたのでinsert,deleteに合わせて省略可能にする
