### PR TITLE
Fix array key in linked resources body

### DIFF
--- a/BEAR/Ro/Prototype/Link.php
+++ b/BEAR/Ro/Prototype/Link.php
@@ -86,7 +86,7 @@ class BEAR_Ro_Prototype_Link extends BEAR_Base
         $class = get_class($rootRo);
         assert(method_exists($class, 'onLink'));
         // ルートリソース
-        $firstUri = strtolower(str_replace(DIRECTORY_SEPARATOR, '_', $config['uri']));
+        $firstUri = strtolower(str_replace('/', '_', $config['uri']));
         $link = $body = $rootRo->getBody();
         $isCollection = (count($body) !== count($body, COUNT_RECURSIVE));
         if ($isCollection === true) {


### PR DESCRIPTION
WindowsとLinuxなど、DIRECTORY_SEPARATORが異なる環境でリンクありのリソースリクエストで取得された結果配列のキーが変わってしまいます。

以下の様なリクエストの場合、
```
$params = ['uri' => 'Blog/Article'];
$article = $resource->read($params)->link('user')->getBody(true);
```

- windowsだと
```
echo isset($article['blog_article']); // false
echo isset($article['blog/article']); // true
```

- linuxだと
```
echo isset($article['blog_article']); // true
echo isset($article['blog/article']); // false
```

この問題のFIXです。