### PR TITLE
[fix]app.ymlでBEAR_Smartyを別クラスで上書きするとlogが残らないバグを修正

### DIFF
--- a/BEAR/Log.php
+++ b/BEAR/Log.php
@@ -274,10 +274,10 @@ ____SQL;
                 include 'BEAR/vendors/debuglib.php';
             }
             $log['var'] = show_vars('trim_tabs:2;show_objects:1;max_y:100;avoid@:1; return:1');
-            if (class_exists('BEAR_Smarty', false)) {
+            if (BEAR::exists('BEAR_Smarty')) {
                 $smarty = BEAR::dependency('BEAR_Smarty');
-                unset($smarty->_tpl_vars['content_for_layout']);
-                $log['smarty'] = $smarty->_tpl_vars;
+                $log['smarty'] = $smarty->get_template_vars();
+                unset($log['smarty']['content_for_layout']);
             } else {
                 $log['smarty'] = '';
             }


### PR DESCRIPTION
BEAR_Smartyを上書きした場合、class_existsではfalseになるのでBEARのレジストリで判断する。
テンプレートの値の取得は直接プロパティを取得しないで関数で取得する。